### PR TITLE
Attempt to find canonical URLs

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -262,9 +262,12 @@ async fn post_work(
             }
         }
         redis.del(format!("pages:linkedfrom:{}", orig_url)).await?;
-        redis
-            .sadd(format!("pages:linkedfrom:{}", result_url), linked_from)
-            .await?;
+
+        if !linked_from.is_empty() {
+            redis
+                .sadd(format!("pages:linkedfrom:{}", result_url), linked_from)
+                .await?;
+        }
 
         // Update page sets
         redis.sadd("pages", &[result_url.clone()]).await?;
@@ -274,11 +277,6 @@ async fn post_work(
     } else {
         redis.del(format!("redirect:{}", orig_url)).await?;
     }
-
-    // TODO: handle link redirects changing properly
-    //  - merge the two records together
-    //  - update old links
-    //  - update page set
 
     // Update the page metadata
     redis


### PR DESCRIPTION
This MR tries to handle situations where someone's hosting the same page on a set of slightly different URLs (for instance, http://example.com, https://example.com, http://www.example.com, https://www.example.com).

The scraper will attempt to identify a canonical version of the current URL using either a [`rel=canonical` tag](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method) (preferred) or an [`og:url` tag](https://ogp.me/) (fallback). If either of these are found, the scraper will redirect to the referenced URL before continuing. This redirection gets reported to the server in the same way an HTTP 301 would be reported.